### PR TITLE
fix bug in pythondialog: expected an empty output

### DIFF
--- a/scripts/run_letsencrypt.py
+++ b/scripts/run_letsencrypt.py
@@ -45,7 +45,7 @@ def renew_domains():
                 server_param = '--staging'
 
             exit_code, result = commands.getstatusoutput('certbot --standalone --standalone-supported-challenges\
-              http-01 --agree-tos --renew-by-default {}\
+              http-01 --agree-tos -t --renew-by-default {}\
               --email $EMAIL -d {} certonly'.format(server_param, domain))
             if exit_code > 0:
                 print(result)


### PR DESCRIPTION
i got `from u'infobox', but got: u'Error opening terminal: unknown.\n'Please see the logfile 'certbot.log' for more details.`
according to this issue https://github.com/certbot/certbot/issues/2882 adding -t fix the problem.
